### PR TITLE
Manjše spremembe

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,10 +9,10 @@
 celo glavni() {
 
   celo a = 12;
-  realno b = 1.0;
+  dvojno b = 1.0;
 
   znak niz[] = "slovenščina";
-  celo *seznam = dodelispomin(5 * velikost(celo));
+  celo *seznam = pdodeli(6 * velikost(celo));
 
   ce (seznam == NIC) {
     natisnio("Premalo spomina");
@@ -20,14 +20,15 @@ celo glavni() {
   }
 
   za (celo i = 0; i < 5; i++) {
-    seznam[i] = i;
+    seznam[i] = 65 + i;
   }
-
-  znak z = " ";
+  seznam[5] = 0;
+  
+  znak z = ' ';
   celo stevec = 0;
   dokler (z != '\0') {
-    z = seznam[stevec];
     natisnio("%c ", z);
+    z = seznam[stevec];
     stevec++;
   }
 

--- a/slovenščina.h
+++ b/slovenščina.h
@@ -11,15 +11,15 @@
 #define znak char
 #define celo int
 #define plavajoce float
-#define realno double
+#define dvojno double
 #define dolgo long
 #define vrni return
 #define ce if
 #define sicer else
 #define prazno void
-#define zamenjaj switch
+#define izberi switch
 #define primer case
-#define dodelispomin malloc
+#define pdodeli malloc
 #define sprosti free
 #define velikost sizeof
 #define glavni main
@@ -34,4 +34,4 @@
 #define dzapri fclose
 #define dberi fread
 #define struktura struct
-#define definirajtip typedef
+#define doltip typedef


### PR DESCRIPTION
Ponosen sem, da lahko podajam predloge v tem monumentalnem projektu izjemnega pomena za slovensko narodno samobitnost.

##### Spremembe prevodov

- `double` se po mojem prevede v `dvojno`. `realno` bi bil `real`, kot v, recumo, Pascalu.
- `switch` ne zamenjuje, temveč izbira. Angleškemu originalu bi sicer najbolj ustrezalo stikalo ali preklop. Ampak se mi zdi `izberi` boljše.
- Spominu se bolj prav reče pomnilnik. (Pa ne vem točno, zakaj. Ampak ne samo računalniki, še nevrologi so mi težili s tem.) Če je "m" v `malloc` "memory", potem bi bilo mogoče bolj prav `pdodeli`.
- `typedef` je okrajšava za `type definition`, torej lahko tudi v slovenščini okrajšamo. Kleni Slovenci pa ne definiramo, temveč določimo. Zato predlagam `doltip`.

##### Spremembe primera

Prej je izpisal `\0` in končal zanko.